### PR TITLE
Fix typo in warning message

### DIFF
--- a/custom_components/zonneplan_one/button.py
+++ b/custom_components/zonneplan_one/button.py
@@ -150,4 +150,4 @@ class ZonneplanButton(CoordinatorEntity, ButtonEntity):
                 self._connection_uuid, charge_point_uuid
             )
         else:
-            _LOGGER.warning("Unknonw button action for %s", self._button_key)
+            _LOGGER.warning("Unknown button action for %s", self._button_key)


### PR DESCRIPTION
## Summary
- fix spelling in button action warning

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684274a24b8c8333b85be12d6ef0f06b