### PR TITLE
Fix typos in Dutch translations

### DIFF
--- a/custom_components/zonneplan_one/translations/nl.json
+++ b/custom_components/zonneplan_one/translations/nl.json
@@ -13,7 +13,7 @@
         "description": "Controleer je mailbox op een mail van Zonneplan en klik op de link in die mail *(kan enkele minuten duren voordat de mail binnenkomt)*. Ga hier vervolgens verder door op **VOLGENDE** te klikken."
       },
       "reauth_confirm": {
-        "title": "Verifieer opnieuw je Zonnneplan login",
+        "title": "Verifieer opnieuw je Zonneplan login",
         "description": "Herauthenticatie van je account is nodig. Ga verder om Zonneplan om een nieuwe login mail op te vragen."
       }
     },
@@ -27,7 +27,7 @@
     },
     "error": {
       "failed_to_request_login": "Het opvragen van een login link ging mis *(controleer de logs)*",
-      "no_password": "Nog een wachtwoord ontvangen *(heb je op de link uit de mail van Zonnneplen geklikt?)*"
+      "no_password": "Nog een wachtwoord ontvangen *(heb je op de link uit de mail van Zonneplan geklikt?)*"
     }
   }
 }


### PR DESCRIPTION
## Summary
- fix spelling for "Zonneplan" in Dutch translation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842752dedf48333afa356879a9d6ec0